### PR TITLE
プロフィールページへのリンクが間違ってたので修正した。

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <ul>
   <% if logged_in? %>
-    <li><%= link_to "Profile", user_path(current_user) %></li>
+    <li><%= link_to "Profile", profile_path(current_user) %></li>
     <li><%= link_to "Log out", logout_path, method: :delete %></li>
   <% else %>
     <li><%= link_to "Log in", login_path %></li>


### PR DESCRIPTION
### 何を解決するのか

プロフィールページへのリンクパスが`user`になっていたので、`profile`に飛ぶように修正した。

### 詳細

```
<li><%= link_to "Profile", profile_path(current_user) %></li>
```


### レビューポイント

(レビュアーに pull request のレビューのポイントを書きます)

### レビュアー

@tsubasa-sris 
