### PR TITLE
ユーザがsignup後に前のユーザ情報が見えてしまう問題を解決した。

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+
   def new
     @user = User.new
 
@@ -8,11 +9,10 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       #ユーザ登録が成功した時点でProfileも作成する
-      @profile = Profile.new(user_id: @user.id).save
+      @profile = Profile.create(user_id:@user.id)
       log_in @user
       # flash[:success] = "アカウント登録に成功しました!"
       #redirect_to @user
-      @profile = Profile.create(user_id:@user.id)
       redirect_to '/welcome'
     else
       render 'new'
@@ -25,4 +25,14 @@ class UsersController < ApplicationController
      params.require(:user).permit(:name, :email, :password,
                                   :password_confirmation)
    end
+
+   # beforeアクション
+
+  # ログイン済みユーザーかどうか確認
+  def logged_in_user
+    unless logged_in?
+      flash[:danger] = "Please log in."
+      redirect_to login_url
+    end
+  end
 end


### PR DESCRIPTION
### 何を解決するのか

ユーザがsignup後に前のユーザ情報が見えてしまう問題を解決した。

関連Issue
https://github.com/Fendo181/osan_dev/issues/21

### 詳細

ユーザが作成された時点でプロフィールも一緒に作成しているが、誤って2回作成していた。
(恐らく消し忘れ)

原因の解説。

```rb
  def create
    @user = User.new(user_params)
    if @user.save
      #ユーザ登録が成功した時点でProfileも作成する
      ## プロフィールと関連したユーザが作られる1
      @profile = Profile.new(user_id: @user.id).save
      log_in @user

       ## プロフィールと関連したユーザが作られる2
      @profile = Profile.create(user_id:@user.id)
      redirect_to '/welcome'
    else
      render 'new'
    end
  end
```

#### 解説

ユーザがアカウントを作成すると、ユーザモデルとプロフィールモデルが紐づいているのでユーザとプロフィールが1つづつ作られるべきだが誤ってプロフィールが2つ作られていた。

従って`user_id:1`に対して`profile_id:1`,`profile_id:2`が紐づいている状態になる。
プロフィールページは`user_id`と紐づいた`profile_id`のプロフィール情報を取得しているので以下のように、取得する情報がずれてしまった状態が発生した。　

```
ユーザがアカウントを作る→user_id 1 →profile_id1:  user_1のプロフィールを見に行く。
ユーザがアカウントを作る→user_id 2→profile_id2:  実質user_1のプロフィールを見に行く。
ユーザがアカウントを作る→user_id 3→profile_id3:  実質user_2のプロフィールを見に行く。
ユーザがアカウントを作る→user_id 4→profile_id4:  実質user_2のプロフィールを見に行く。

```

今回

### レビューポイント

(レビュアーに pull request のレビューのポイントを書きます)

### レビュアー

(pull request のレビュアーを決めてメンションします)
